### PR TITLE
fix installation to path not working

### DIFF
--- a/scripts/change_url
+++ b/scripts/change_url
@@ -14,6 +14,11 @@ ynh_script_progression "Updating NGINX web server configuration..."
 # this will most likely adjust NGINX config correctly
 ynh_config_change_url_nginx
 
+if [ $path != "/" ]
+then
+    ynh_replace --match="<base href=\"" --replace="<base href=\"$path" --file="$install_dir/index.html"
+fi
+
 #=================================================
 # END OF SCRIPT
 #=================================================

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -7,17 +7,22 @@
 source /usr/share/yunohost/helpers
 
 #=================================================
+# ADJUST BASE HREF
+#=================================================
+ynh_script_progression "Adjusting source files..."
+
+if [ $path != "/" ]
+then
+    ynh_replace --match="<base href=\"$old_path" --replace="<base href=\"$new_path" --file="$install_dir/index.html"
+fi
+
+#=================================================
 # MODIFY URL IN NGINX CONF
 #=================================================
 ynh_script_progression "Updating NGINX web server configuration..."
 
 # this will most likely adjust NGINX config correctly
 ynh_config_change_url_nginx
-
-if [ $path != "/" ]
-then
-    ynh_replace --match="<base href=\"" --replace="<base href=\"$path" --file="$install_dir/index.html"
-fi
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/install
+++ b/scripts/install
@@ -14,6 +14,11 @@ ynh_script_progression "Setting up source files..."
 # Download, check integrity, uncompress and patch the source from manifest.toml
 ynh_setup_source --dest_dir="$install_dir"
 
+if [ $path != "/" ]
+then
+    ynh_replace --match="<base href=\"" --replace="<base href=\"$path" --file="$install_dir/index.html"
+fi
+
 #=================================================
 # SYSTEM CONFIGURATION
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -14,6 +14,11 @@ ynh_script_progression "Upgrading source files..."
 # Download, check integrity, uncompress and patch the source from manifest.toml
 ynh_setup_source --dest_dir="$install_dir" --full_replace
 
+if [ $path != "/" ]
+then
+    ynh_replace --match="<base href=\"" --replace="<base href=\"$path" --file="$install_dir/index.html"
+fi
+
 #=================================================
 # REAPPLY SYSTEM CONFIGURATION
 #=================================================


### PR DESCRIPTION
## Problem

- #4 
- installing package using any path other than `/` did not work

## Solution

- index.html has `base href` entry where path can be declared
- add `ynh_replace` if `$path` is `!= /` in install, upgrade, and change-url scripts
 
## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
